### PR TITLE
BUG: Fix runtime error related to missing LabelStatisticsLogic. Fixes #5

### DIFF
--- a/Py/qSlicerLongitudinalPETCTModuleWidget.py
+++ b/Py/qSlicerLongitudinalPETCTModuleWidget.py
@@ -1,6 +1,7 @@
 from __main__ import vtk, qt, ctk, slicer
 
 from Editor import EditorWidget
+from LabelStatistics import LabelStatisticsLogic
 from SlicerLongitudinalPETCTModuleViewHelper import SlicerLongitudinalPETCTModuleViewHelper as ViewHelper
 from SlicerLongitudinalPETCTModuleSegmentationHelper import SlicerLongitudinalPETCTModuleSegmentationHelper as SegmentationHelper
 


### PR DESCRIPTION
This commit fixes a regression most likely introduced by r24155 (ENH: Fixes

Error fixed by this commit is the following:

```
File "/home/jcfr/.config/NA-MIC/Extensions-24309/LongitudinalPETCT/lib/Slicer-4.4/qt-loadable-modules/Python/qSlicerLongitudinalPETCTModuleWidget.py", line 1445, in calculateSUVsAndStatistics
  stats = LabelStatisticsLogic(study.GetPETVolumeNode(), study.GetPETLabelVolumeNode())
NameError: global name 'LabelStatisticsLogic' is not defined
```
