### PR TITLE
Fix build error and add qt5 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.5)
 
 #-----------------------------------------------------------------------------
 if(NOT Slicer_SOURCE_DIR)

--- a/MRML/vtkMRMLLongitudinalPETCTStudyNode.cxx
+++ b/MRML/vtkMRMLLongitudinalPETCTStudyNode.cxx
@@ -470,16 +470,6 @@ vtkMRMLLongitudinalPETCTStudyNode::ObserveRegistrationTransform(bool observe)
                   != this->RegistrationTransformNode)
             roiNode->SetAndObserveTransformNodeID(
                 this->RegistrationTransformNode->GetID());
-
-
-          vtkMRMLVolumePropertyNode* propNode =
-              this->VolumeRenderingDisplayNode->GetVolumePropertyNode();
-          if (propNode
-              && propNode->GetParentTransformNode()
-                  != this->RegistrationTransformNode)
-            propNode->SetAndObserveTransformNodeID(
-                this->RegistrationTransformNode->GetID());
-
         }
     }
   else
@@ -496,11 +486,6 @@ vtkMRMLLongitudinalPETCTStudyNode::ObserveRegistrationTransform(bool observe)
               this->VolumeRenderingDisplayNode->GetROINode();
           if (roiNode)
             roiNode->SetAndObserveTransformNodeID(NULL);
-
-          vtkMRMLVolumePropertyNode* propNode =
-              this->VolumeRenderingDisplayNode->GetVolumePropertyNode();
-          if (propNode)
-            propNode->SetAndObserveTransformNodeID(NULL);
         }
     }
 

--- a/Quantification/CMakeLists.txt
+++ b/Quantification/CMakeLists.txt
@@ -1,3 +1,1 @@
-cmake_minimum_required(VERSION 2.8.7)
-
 add_subdirectory(PETSUVImageMaker)

--- a/Quantification/PETSUVImageMaker/CMakeLists.txt
+++ b/Quantification/PETSUVImageMaker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.5)
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME PETSUVImageMaker)

--- a/Quantification/PETSUVImageMaker/itkDCMTKFileReader.cxx
+++ b/Quantification/PETSUVImageMaker/itkDCMTKFileReader.cxx
@@ -24,22 +24,22 @@
 #define INCLUDE_CSTDIO
 #define INCLUDE_CSTRING
 
-#include "dcdict.h"             // For DcmDataDictionary
-#include "dcsequen.h"        /* for DcmSequenceOfItems */
-#include "dcvrcs.h"          /* for DcmCodeString */
-#include "dcvrfd.h"          /* for DcmFloatingPointDouble */
-#include "dcvrfl.h"          /* for DcmFloatingPointDouble */
-#include "dcvrus.h"          /* for DcmUnsignedShort */
-#include "dcvris.h"          /* for DcmIntegerString */
-#include "dcvrobow.h"        /* for DcmOtherByteOtherWord */
-#include "dcvrui.h"          /* for DcmUniqueIdentifier */
-#include "dcfilefo.h"        /* for DcmFileFormat */
-#include "dcdeftag.h"        /* for DCM_NumberOfFrames */
-#include "dcvrlo.h"          /* for DcmLongString */
-#include "dcvrtm.h"          /* for DCMTime */
-#include "dcvrda.h"          /* for DcmDate */
-#include "dcvrpn.h"          /* for DcmPersonName */
-// #include "diregist.h"     /* include to support color images */
+#include "dcmtk/dcmdata/dcdict.h"             // For DcmDataDictionary
+#include "dcmtk/dcmdata/dcsequen.h"        /* for DcmSequenceOfItems */
+#include "dcmtk/dcmdata/dcvrcs.h"          /* for DcmCodeString */
+#include "dcmtk/dcmdata/dcvrfd.h"          /* for DcmFloatingPointDouble */
+#include "dcmtk/dcmdata/dcvrfl.h"          /* for DcmFloatingPointDouble */
+#include "dcmtk/dcmdata/dcvrus.h"          /* for DcmUnsignedShort */
+#include "dcmtk/dcmdata/dcvris.h"          /* for DcmIntegerString */
+#include "dcmtk/dcmdata/dcvrobow.h"        /* for DcmOtherByteOtherWord */
+#include "dcmtk/dcmdata/dcvrui.h"          /* for DcmUniqueIdentifier */
+#include "dcmtk/dcmdata/dcfilefo.h"        /* for DcmFileFormat */
+#include "dcmtk/dcmdata/dcdeftag.h"        /* for DCM_NumberOfFrames */
+#include "dcmtk/dcmdata/dcvrlo.h"          /* for DcmLongString */
+#include "dcmtk/dcmdata/dcvrtm.h"          /* for DCMTime */
+#include "dcmtk/dcmdata/dcvrda.h"          /* for DcmDate */
+#include "dcmtk/dcmdata/dcvrpn.h"          /* for DcmPersonName */
+// #include "dcmtk/dcmimage/diregist.h"     /* include to support color images */
 #include "vnl/vnl_cross.h"
 
 

--- a/Quantification/PETSUVImageMaker/itkDCMTKFileReader.h
+++ b/Quantification/PETSUVImageMaker/itkDCMTKFileReader.h
@@ -16,19 +16,25 @@
  *
  *=========================================================================*/
 #ifndef __itkDCMTKFileReader_h
-
 #define __itkDCMTKFileReader_h
+
+// DCMTK includes
+#include "dcmtk/dcmdata/dcxfer.h"
+#include "dcmtk/dcmdata/dcvrds.h"
+#include "dcmtk/dcmdata/dcstack.h"
+#include "dcmtk/dcmdata/dcdatset.h"
+
+// ITK includes
+#include "itkByteSwapper.h"
+#include "itkImageIOBase.h"
+#include "itkIntTypes.h"
+#include "itkMacro.h"
+#include "vnl/vnl_vector.h"
+
+// STD includes
 #include <stack>
 #include <vector>
-#include "itkByteSwapper.h"
-#include "itkIntTypes.h"
-#include "vnl/vnl_vector.h"
-#include "dcxfer.h"
-#include "dcvrds.h"
-#include "dcstack.h"
-#include "dcdatset.h"
-#include "itkMacro.h"
-#include "itkImageIOBase.h"
+
 
 class DcmSequenceOfItems;
 class DcmFileFormat;

--- a/qSlicerLongitudinalPETCTModule.cxx
+++ b/qSlicerLongitudinalPETCTModule.cxx
@@ -33,7 +33,10 @@
 #include <vtkSlicerConfigure.h>
 
 //-----------------------------------------------------------------------------
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+#include <QtPlugin>
 Q_EXPORT_PLUGIN2(qSlicerLongitudinalPETCTModule, qSlicerLongitudinalPETCTModule);
+#endif
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_ExtensionTemplate

--- a/qSlicerLongitudinalPETCTModule.h
+++ b/qSlicerLongitudinalPETCTModule.h
@@ -30,6 +30,9 @@ class Q_SLICER_QTMODULES_LONGITUDINALPETCT_EXPORT qSlicerLongitudinalPETCTModule
   public qSlicerLoadableModule
 {
   Q_OBJECT
+#ifdef Slicer_HAVE_QT5
+  Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
+#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:


### PR DESCRIPTION
@fedorov  While testing the recent updates associated with Slicer build system, I ended updating your extension

Issue https://github.com/QIICR/LongitudinalPETCT/issues/9 is fixed by 1b42eef. A entry to the migration guide has also been added. The migration guide associated with VTK6, VTK7, VTK8, Qt5 and Slicer are now all linked of https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide


Please, consider reviewing and testing this set of changes.
Cc: @lassoan @pieper