### PR TITLE
BUG: Fix loading of module UI importing EditorWidget

### DIFF
--- a/Py/qSlicerLongitudinalPETCTModuleWidget.py
+++ b/Py/qSlicerLongitudinalPETCTModuleWidget.py
@@ -3,6 +3,7 @@ import qt
 import ctk
 import slicer
 
+from Editor import EditorWidget
 from LabelStatistics import LabelStatisticsLogic
 from SlicerLongitudinalPETCTModuleViewHelper import SlicerLongitudinalPETCTModuleViewHelper as ViewHelper
 from SlicerLongitudinalPETCTModuleSegmentationHelper import SlicerLongitudinalPETCTModuleSegmentationHelper as SegmentationHelper


### PR DESCRIPTION
Fixes #14

This commit fixes the following error reported when opening the module
in Slicer 4.10.0:

```
Loading Slicer RC file [/home/jcfr/.slicerrc.py]
Traceback (most recent call last):
  File "/home/jcfr/.config/NA-MIC/Extensions-27501/LongitudinalPETCT/lib/Slicer-4.10/qt-loadable-modules/Python/qSlicerLongitudinalPETCTModuleWidget.py", line 432, in setup
    self.__createEditorWidget()
  File "/home/jcfr/.config/NA-MIC/Extensions-27501/LongitudinalPETCT/lib/Slicer-4.10/qt-loadable-modules/Python/qSlicerLongitudinalPETCTModuleWidget.py", line 99, in __createEditorWidget
    self.editorWidget = EditorWidget(editorWidgetParent, False)
NameError: global name 'EditorWidget' is not defined
```