### PR TITLE
COMP: fix to compile with dcmtk 3.6.6

### DIFF
--- a/Quantification/PETSUVImageMaker/itkDCMTKFileReader.cxx
+++ b/Quantification/PETSUVImageMaker/itkDCMTKFileReader.cxx
@@ -1139,7 +1139,7 @@ DCMTKFileReader
 {
   DcmDataDictionary &dict = dcmDataDict.wrlock();
   dict.addEntry(entry);
-  dcmDataDict.unlock();
+  dcmDataDict.wrunlock();
 }
 
 unsigned


### PR DESCRIPTION
See:
https://support.dcmtk.org/docs/classGlobalDcmDataDictionary.html#ae5133e0497e159163b0258b05d3d8e5c